### PR TITLE
Option to pipe output to log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ logger.WithoutDebug()
 logger.Debug("Test debug output") // This message will not be printed
 ```
 
+## Pipe output to log file
+
+You can simultaneously write to stdout and to a log file. Colors will only appear on the console, not in the log file.
+
+```go
+logger := log.New(os.Stdout).WithLogFile("test.log")
+```
+
 ## Be Quiet
 
 If somehow the log is annoying to you, just shush it by calling `(Logger).Quiet()` and **ALL** log output will be

--- a/log.go
+++ b/log.go
@@ -127,7 +127,7 @@ func (l *Logger) WithoutColor() *Logger {
 func (l *Logger) WithLogFile(path string) *Logger {
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
-		l.Error("could not open log file", path)
+		l.Error("could not open log file", path, err)
 	}
 	runtime.SetFinalizer(l, func(l *Logger) {
 		l.Info("closing log file")

--- a/log.go
+++ b/log.go
@@ -109,6 +109,12 @@ func (l *Logger) WithColor() *Logger {
 	return l
 }
 
+func (l *Logger) IsColored() bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.color
+}
+
 // WithoutColor explicitly turn off colorful features on the log
 func (l *Logger) WithoutColor() *Logger {
 	l.mu.Lock()

--- a/log.go
+++ b/log.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/withmandala/go-log/colorful"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // FdWriter interface extends existing io.Writer with file descriptor function
@@ -94,7 +94,7 @@ var (
 // automatically detect terminal coloring support
 func New(out FdWriter) *Logger {
 	return &Logger{
-		color:     terminal.IsTerminal(int(out.Fd())),
+		color:     term.IsTerminal(int(out.Fd())),
 		out:       out,
 		timestamp: true,
 	}


### PR DESCRIPTION
Often I want to display colored output on the console but also have the output (not colored) in a log file.
This PR adds such an option. Just use
```go
logger := log.New(os.Stdout).WithLogFile("test.log")
```
and it will automatically append your logs to this file, ignoring colors that are still printed to the console.